### PR TITLE
feat: Add `before` function callback for custom format

### DIFF
--- a/lua/lspkind/init.lua
+++ b/lua/lspkind/init.lua
@@ -126,6 +126,10 @@ function lspkind.cmp_format(opts)
   end
 
   return function(entry, vim_item)
+    if opts.before then
+          vim_item = opts.before(entry, vim_item)
+    end
+        
     vim_item.kind = lspkind.symbolic(vim_item.kind, opts)
 
     if opts.menu ~= nil then


### PR DESCRIPTION
Hello, this allows me to do something like this (just replaced `cb` with `before` though)

<img width="732" alt="Capture d’écran 2021-12-01 à 15 21 33" src="https://user-images.githubusercontent.com/5306901/144251095-e47a7c08-fc70-472b-a6ac-a794b88ef435.png">

In order to apply custom format:

![Uploading Capture d’écran 2021-12-01 à 15.22.17.png…]()
